### PR TITLE
fix errors caused by null and empty values on training schools add/edit

### DIFF
--- a/components/simpleselect.tsx
+++ b/components/simpleselect.tsx
@@ -15,7 +15,7 @@ export default function SimpleSelector(props) {
                 }) => (
                     <>
                         <select className='form-control' {...field}>
-                            <option value=''>Select one</option>
+                            <option value={null}>Select one</option>
 
                             {items && items.map(item =>
 

--- a/modules/trainingSchools/components/edit.tsx
+++ b/modules/trainingSchools/components/edit.tsx
@@ -21,7 +21,7 @@ export default function School(props: schoolDataEditProps) {
             .required("Principal is required")
             .min(4, "Principal name must be at least 4 characters")
             .max(60, "Principal namme must not exceed 60 characters"),
-        registrationStatus: Yup.string().oneOf(statuses, 'Will default to full registration'),
+        registrationStatus: Yup.string().oneOf([null,...statuses], 'Will default to full registration').nullable(),
         email: Yup.string().email("Email is invalid")
         .nullable(),
         district: Yup.string().required("District is required")

--- a/modules/trainingSchools/lib/schools.ts
+++ b/modules/trainingSchools/lib/schools.ts
@@ -9,7 +9,7 @@ export function getTrainingSchool(id) {
   return axiosApi.get(`${API_URL}/api/v1/trainingSchools/${id}`)
 }
 
-export function createTrainingSchool(data:schoolEditObj) {
+export function createTrainingSchool(data) {
   return axiosApi.post(`${API_URL}/api/v1/trainingSchools/`,data)
 }
 
@@ -17,6 +17,6 @@ export function editTrainingSchool(data,id) {
   return axiosApi.patch(`${API_URL}/api/v1/trainingSchools/${id}`,data)
 }
 
-export function deleteTrainingSchool(id:string) {
+export function deleteTrainingSchool(id) {
   return axiosApi.delete(`${API_URL}/api/v1/trainingSchools/${id}`)
 }

--- a/modules/trainingSchools/utils.ts
+++ b/modules/trainingSchools/utils.ts
@@ -8,5 +8,5 @@ export function convertToString(field:any){
     return field?field.toString():null;
 }
 export function nonNullValues(obj){
-    return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null));
+    return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null && v!=''));
 }

--- a/pages/trainingSchools/create.tsx
+++ b/pages/trainingSchools/create.tsx
@@ -9,6 +9,7 @@ import Edit from '../../modules/trainingSchools/components/edit'
 import { schoolEditObj } from '../../modules/trainingSchools/store/types'
 import { createTrainingSchool } from '../../modules/trainingSchools/lib/schools'
 import { useRouter } from 'next/router'
+import { nonNullValues } from '../../modules/trainingSchools/utils';
 
 
 export default function CreateSchool() {
@@ -16,14 +17,15 @@ export default function CreateSchool() {
     const [state, dispatch] = useReducer(editReducer,editInitialState);
     const handleSubmit = async (values:schoolEditObj) => {
         dispatch({ type: "editSchoolLoadingUpdate", payload: true });
-        await createTrainingSchool(values).then(() => {
+        await createTrainingSchool(nonNullValues(values)).then(() => {
             toast.success("Successfully created");
             dispatch({ type: "editSchoolLoadingUpdate", payload: false });
             router.push('/trainingSchools');
         }).catch(error => {
+            dispatch({ type: "editSchoolLoadingUpdate", payload: false });
             toast.error("Failed to create Contact");
             toast.error(error.message);
-            dispatch({ type: "editSchoolLoadingUpdate", payload: false });
+            toast.error(error.response.data.message);
         });
     }
     const {school,isLoading}=state

--- a/pages/trainingSchools/update/[id].tsx
+++ b/pages/trainingSchools/update/[id].tsx
@@ -10,7 +10,6 @@ import Edit from '../../../modules/trainingSchools/components/edit'
 import { schoolEditObj } from '../../../modules/trainingSchools/store/types'
 import { editTrainingSchool, getTrainingSchool } from '../../../modules/trainingSchools/lib/schools'
 import { useRouter } from 'next/router'
-import { countReset } from 'console'
 import { convertToString, flattenArray, nonNullValues } from '../../../modules/trainingSchools/utils'
 import Loader from '../../../components/loader'
 


### PR DESCRIPTION
# Description

Users could not add school without selecting registration status which brought an unnecessary error.
It is also not a necessary field. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a training school without selecting a registration status or editing the health facility, level and pass rate fields


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
