### PR TITLE
View training Schools under a contact

### DIFF
--- a/modules/trainingSchools/components/all.tsx
+++ b/modules/trainingSchools/components/all.tsx
@@ -14,7 +14,7 @@ export default function Schools({
             <table className="table">
                 <thead className={utilStyles.sticky}>
                     <tr>
-                        <td colSpan={4}><b>Training Schools</b></td>
+                        <td colSpan={5}><b>Training Schools</b></td>
                     </tr>
                     <tr>
                         <th>#</th>

--- a/modules/trainingSchools/components/all.tsx
+++ b/modules/trainingSchools/components/all.tsx
@@ -37,7 +37,7 @@ export default function Schools({
                                 <Date dateString={createdAt} />
                             </td>
                             <td className={utilStyles.lightText}>
-                                <Link href={`trainingSchools/view/${id}`}><a className='btn btn-sm btn-outline-primary' >View</a></Link>
+                                <Link href={`/trainingSchools/view/${id}`}><a className='btn btn-sm btn-outline-primary' >View</a></Link>
                             </td>
                         </tr>
                     ))}

--- a/pages/contacts/view/[id].tsx
+++ b/pages/contacts/view/[id].tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router'
 import { getContact } from '../../../modules/contacts/lib/contacts'
 import Loader from '../../../components/loader'
 import Link from 'next/link'
+import Schools from '../../../modules/trainingSchools/components/all';
 
 export default function Contact() {
     
@@ -35,6 +36,8 @@ export default function Contact() {
         {data && <><h5>{data.data.phoneNumber}</h5>
           <Date dateString={data.data.createdAt}></Date>
         </>}
+        <hr/>
+        {data && <Schools allTrainingSchools={data.data.trainingschools}></Schools>}
         {isLoading && <Loader isLoading={isLoading}></Loader>}
 
       </article>


### PR DESCRIPTION
# Description

- [Ensure users can view schools under a contact](https://github.com/patrickf949/trainhub/commit/4f8166ad735a13f248e38ef5e174d3fafe223126)
- [Fix invalid route in training schools under a contact](https://github.com/patrickf949/trainhub/commit/699e47017430b908f1b13eb520a4d43598594f67)
Fixes #24

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

When you select a contact under contacts you should be able to view training schools under that contact if available.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
