### PR TITLE
Users should be able to view schools under a contact

### DIFF
--- a/components/empty.tsx
+++ b/components/empty.tsx
@@ -1,0 +1,14 @@
+
+
+export default function Empty(props:{columns:number,label:string}) {
+    const {columns,label}=props
+    return (
+        <tfoot>
+           <tr>
+            <td colSpan={columns}>
+                No {label} available
+            </td>
+           </tr>
+        </tfoot>
+    );
+};

--- a/modules/contacts/components/all.tsx
+++ b/modules/contacts/components/all.tsx
@@ -3,18 +3,21 @@ import utilStyles from '../../../styles/utils.module.css'
 import Link from 'next/link'
 import Date from '../../../components/date'
 import { contactObj } from '../store/types'
+import Empty from '../../../components/empty'
 
 export default function Contacts({
     allContacts
 }:{
     allContacts:contactObj[]
 }) {
+    const title = 'Contacts'
+    const columns = 4
     return (
         <>
             <table className="table">
                 <thead className={utilStyles.sticky}>
                     <tr>
-                        <td colSpan={4}><b>Contacts</b></td>
+                        <td colSpan={columns}><b>{title}</b></td>
                     </tr>
                     <tr>
                         <th>#</th>
@@ -39,6 +42,7 @@ export default function Contacts({
                     ))}
 
                 </tbody>
+                {!allContacts.length && <Empty columns={columns} label={title}/>}
             </table>
 
 

--- a/modules/contacts/components/single.tsx
+++ b/modules/contacts/components/single.tsx
@@ -1,44 +1,26 @@
 
 import utilStyles from '../../../styles/utils.module.css'
 import Date from '../../../components/date'
+import Schools from '../../trainingSchools/components/all';
 
-export default function getAllContacts({
+export default function SingleContact({
     contact
-}:{
-    contact:{
-        phoneNumber:string,
-        createdAt:string,
-        id:string,
+}: {
+    contact: {
+        phoneNumber: string,
+        createdAt: string,
+        id: string,
+        trainingschools: []
     }
 }) {
-    const {phoneNumber,createdAt}=contact;
-    
+
+    const { phoneNumber, createdAt, trainingschools } = contact;
     return (
-        <>
-            <table className="table">
-                <thead>
-                    <tr>
-                        <th>#</th>
-                        <th scope="col">Phone Number</th>
-                        <th scope="col">CreatedAt</th>
-                    </tr>
-                </thead>
-                <tbody>
+        <><h5>{phoneNumber}</h5>
+            <Date dateString={createdAt}></Date>
 
-                    <tr >
-                        <td></td>
-                        <td>  <a>{phoneNumber}</a>
-                        </td>
-                        <td className={utilStyles.lightText}>
-                            <Date dateString={createdAt} />
-                        </td>
-                    </tr>
-
-
-                </tbody>
-            </table>
-
-
+            <hr />
+            <Schools allTrainingSchools={trainingschools}></Schools>
         </>
     )
 }

--- a/modules/trainingSchools/components/all.tsx
+++ b/modules/trainingSchools/components/all.tsx
@@ -14,7 +14,7 @@ export default function Schools({
             <table className="table">
                 <thead className={utilStyles.sticky}>
                     <tr>
-                        <td colSpan={4}><b>Training Schools</b></td>
+                        <td colSpan={5}><b>Training Schools</b></td>
                     </tr>
                     <tr>
                         <th>#</th>

--- a/modules/trainingSchools/components/all.tsx
+++ b/modules/trainingSchools/components/all.tsx
@@ -3,18 +3,22 @@ import utilStyles from '../../../styles/utils.module.css'
 import Link from 'next/link'
 import Date from '../../../components/date'
 import { schoolData } from '../store/types'
+import Empty from '../../../components/empty'
 
 export default function Schools({
     allTrainingSchools
 }: {
     allTrainingSchools: schoolData[]
 }) {
+    const title = 'Training Schools'
+    const columns = 5
+
     return (
         <>
             <table className="table">
                 <thead className={utilStyles.sticky}>
                     <tr>
-                        <td colSpan={5}><b>Training Schools</b></td>
+                        <td colSpan={columns}><b>{title}</b></td>
                     </tr>
                     <tr>
                         <th>#</th>
@@ -43,6 +47,7 @@ export default function Schools({
                     ))}
 
                 </tbody>
+                {!allTrainingSchools.length && <Empty columns={columns} label={title}/>}
             </table>
         </>
     )

--- a/modules/trainingSchools/components/all.tsx
+++ b/modules/trainingSchools/components/all.tsx
@@ -37,7 +37,7 @@ export default function Schools({
                                 <Date dateString={createdAt} />
                             </td>
                             <td className={utilStyles.lightText}>
-                                <Link href={`trainingSchools/view/${id}`}><a className='btn btn-sm btn-outline-primary' >View</a></Link>
+                                <Link href={`/trainingSchools/view/${id}`}><a className='btn btn-sm btn-outline-primary' >View</a></Link>
                             </td>
                         </tr>
                     ))}

--- a/modules/trainingSchools/components/single.tsx
+++ b/modules/trainingSchools/components/single.tsx
@@ -5,6 +5,7 @@ import Date from '../../../components/date'
 import { schoolDataProps } from '../store/types';
 import Contacts from '../../contacts/components/all';
 import Row from '../../../components/keyValue'
+import Empty from '../../../components/empty';
 
 export default function School({
     schoolData
@@ -63,6 +64,7 @@ export default function School({
                         ))}
 
                     </tbody>
+                    {!courses.length && <Empty columns={7} label={'Courses'}/>}
                 </table>}
 
                 {contacts && <Contacts allContacts={contacts}></Contacts>}

--- a/pages/contacts/view/[id].tsx
+++ b/pages/contacts/view/[id].tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router'
 import { getContact } from '../../../modules/contacts/lib/contacts'
 import Loader from '../../../components/loader'
 import Link from 'next/link'
+import Schools from '../../../modules/trainingSchools/components/all';
 
 export default function Contact() {
     
@@ -35,6 +36,8 @@ export default function Contact() {
         {data && <><h5>{data.data.phoneNumber}</h5>
           <Date dateString={data.data.createdAt}></Date>
         </>}
+        <hr/>
+        {data && <Schools allTrainingSchools={data.data.trainingschools}></Schools>}
         {isLoading && <Loader isLoading={isLoading}></Loader>}
 
       </article>

--- a/pages/contacts/view/[id].tsx
+++ b/pages/contacts/view/[id].tsx
@@ -8,6 +8,7 @@ import { getContact } from '../../../modules/contacts/lib/contacts'
 import Loader from '../../../components/loader'
 import Link from 'next/link'
 import Schools from '../../../modules/trainingSchools/components/all';
+import SingleContact from '../../../modules/contacts/components/single';
 
 export default function Contact() {
     
@@ -16,7 +17,7 @@ export default function Contact() {
         await getContact(router.query.id)
             .then((res) => {
                 toast.success('Contact Loaded');
-                return res.data;
+                return res.data.data;
             })
             .catch((error) => {
                 toast.error("Failed to load Contact");
@@ -32,14 +33,11 @@ export default function Contact() {
         <title>Training Hub Contact</title>
       </Head>
       <article>
+      
       <p> <Link href="/">Menu</Link>&nbsp;&gt;&nbsp;<Link href="/contacts">Contacts</Link></p>
-        {data && <><h5>{data.data.phoneNumber}</h5>
-          <Date dateString={data.data.createdAt}></Date>
-        </>}
-        <hr/>
-        {data && <Schools allTrainingSchools={data.data.trainingschools}></Schools>}
-        {isLoading && <Loader isLoading={isLoading}></Loader>}
-
+      <Loader isProcessing={isLoading}></Loader>
+        {data && !isLoading  && <SingleContact contact={data}/>
+        }
       </article>
     </Layout>
   )


### PR DESCRIPTION
# Description

- [Ensure users can view schools under a contact](https://github.com/patrickf949/trainhub/commit/4f8166ad735a13f248e38ef5e174d3fafe223126)
- [Fix invalid route in training schools under a contact](https://github.com/patrickf949/trainhub/commit/699e47017430b908f1b13eb520a4d43598594f67)
- [Single contact moved to components](https://github.com/patrickf949/trainhub/commit/1f81c1fd9265374c1f00681abb31c83d3b2c7629)
- [Ensure all tables are catered for when empty](https://github.com/patrickf949/trainhub/commit/d62018296c2eef19c9225cda4763c4ac98ec92b6)

Fixes 
- #26
- #27 
- #28
- #29
- #24


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Under any contact, users should be able to view training schools attached to it.
All tables will show a 'no items label' when empty


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
