### PR TITLE
Fix failed update for schools without a district

### DIFF
--- a/components/selector.tsx
+++ b/components/selector.tsx
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query'
 import Select from "react-select";
 
 export default function Selector(props) {
-    const { getRequest, name, label,placeholder, required } = props;
+    const { getRequest, name, label, placeholder, required } = props;
     const { isLoading, data, } = useQuery(`get${name}`, async () =>
         await getRequest()
             .then((res) => {
@@ -30,21 +30,20 @@ export default function Selector(props) {
                     form,
                     field,
                     meta,
-                }) => (
-                    <>
-                        <Select
-                            value={options ? options.filter(each => field.value.includes(each.value))[0] : null}
-                            options={options}
-                            isLoading={isLoading}
-                            placeholder={placeholder}
-                            onChange={option =>
-                                form.setFieldValue(field.name, option.value)
-                            }
-                        />
-                        {meta.error && (
-                            <div className="text-danger">{meta.error}</div>
-                        )}
-                    </>)}
+                }) => (<>
+                    <Select
+                        value={options ? options.filter(each => each.value === field.value)[0] : ''}
+                        options={options}
+                        isLoading={isLoading}
+                        placeholder={placeholder}
+                        onChange={option =>
+                            form.setFieldValue(field.name, option.value)
+                        }
+                    />
+                    {meta.error && (
+                        <div className="text-danger">{meta.error}</div>
+                    )}
+                </>)}
             </Field>
             <br />
         </>

--- a/modules/trainingSchools/components/single.tsx
+++ b/modules/trainingSchools/components/single.tsx
@@ -9,7 +9,7 @@ import Courses from '../../courses/components/all';
 export default function School({
     schoolData
 }: schoolDataProps) {
-    const { contacts, createdAt, name, principal, courses, registrationStatus, healthFacility, address, email, passRate,level } = schoolData;
+    const { contacts, createdAt, name,district, principal, courses, registrationStatus, healthFacility, address, email, passRate,level } = schoolData;
 
     return (
         <>
@@ -19,6 +19,7 @@ export default function School({
             <Row name={'Registration'} value={registrationStatus}></Row>
             <Row name={'Health Facility'} value={healthFacility}></Row>
             <Row name={'Address'} value={address}></Row>
+            <Row name={'District'} value={district?.name}></Row>
             <Row name={'Email'} value={email}></Row>
             <Row name={'Pass Rate'} value={passRate}></Row>
             <Row name={'Level'} value={level}></Row>

--- a/modules/trainingSchools/utils.ts
+++ b/modules/trainingSchools/utils.ts
@@ -5,8 +5,8 @@ export function flattenArray(array:Array<genericItem>){
 }
 
 export function convertToString(field:any){
-    return field?field.toString():null;
+    return field?field.toString():'';
 }
 export function nonNullValues(obj){
-    return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null && v!=''));
+    return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v !== null && v!==''));
 }

--- a/pages/trainingSchools/update/[id].tsx
+++ b/pages/trainingSchools/update/[id].tsx
@@ -25,16 +25,16 @@ export default function UpdateSchool({schoolId}) {
             .then((res) => {
                 toast.success('School Loaded');
                 dispatch({ type: "editSchoolLoadingUpdate", payload: false });
-                let editschool = res.data.data;
-                editschool = {...editInitialState.school,...nonNullValues(editschool)}
-                editschool.district = editschool.district.id;
-                editschool.contacts = flattenArray(editschool.contacts);
-                editschool.courses = flattenArray(editschool.courses);
-                editschool.passRate = convertToString(editschool.passRate);
-                editschool.level = convertToString(editschool.level);
+                const editschool = res.data.data;
+                let newschool = {...editInitialState.school,...nonNullValues(editschool)}
+                newschool.district =  newschool['districtId']?newschool['districtId']:'';
+                newschool.contacts = flattenArray(editschool.contacts);
+                newschool.courses = flattenArray(editschool.courses);
+                newschool.passRate = convertToString(editschool.passRate);
+                newschool.level = convertToString(editschool.level);
                 delete editschool['id'];
                 delete editschool['districtId'];
-                dispatch({ type: "editSchoolUpdate", payload: editschool });
+                dispatch({ type: "editSchoolUpdate", payload: newschool });
                 return res.data;
             })
             .catch((error) => {


### PR DESCRIPTION
# Description

Schools missing district were still having issues on update, this has been resolved.
Errors regarding schools with null passrate and level will no longer log errors in the console.

#### Fixes 
- [Schools missing district raise issues on update](https://github.com/patrickf949/trainhub/issues/49)
- [User cannot view district of school on single view page](https://github.com/patrickf949/trainhub/issues/51)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Try to updated any school missing a district
- Under any school a user should be able to view the district attached to the school


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
